### PR TITLE
🏷️ Import types from Express 5

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -70,6 +70,8 @@
 		"@natoboram/gigachads.ts-client": "workspace:*",
 		"@natoboram/gigachads.ts-config": "workspace:*",
 		"@types/express": "^5.0.3",
+		"@types/express-serve-static-core": "^5.0.7",
+		"@types/qs": "^6.14.0",
 		"eslint": "^9.32.0",
 		"eslint-config-prettier": "^10.1.8",
 		"globals": "^16.3.0",

--- a/apps/server/src/express/index.ts
+++ b/apps/server/src/express/index.ts
@@ -1,3 +1,0 @@
-export type * from "./locals_obj.ts"
-export type * from "./params_dictionary.ts"
-export type * from "./parsed_qs.ts"

--- a/apps/server/src/express/locals_obj.ts
+++ b/apps/server/src/express/locals_obj.ts
@@ -1,1 +1,0 @@
-export type LocalsObj = Record<string, unknown>

--- a/apps/server/src/express/params_dictionary.ts
+++ b/apps/server/src/express/params_dictionary.ts
@@ -1,1 +1,0 @@
-export type ParamsDictionary = Readonly<Record<string, string>>

--- a/apps/server/src/express/parsed_qs.ts
+++ b/apps/server/src/express/parsed_qs.ts
@@ -1,3 +1,0 @@
-export interface ParsedQs {
-	readonly [key: string]: ParsedQs | ParsedQs[] | string[] | string | undefined
-}

--- a/apps/server/src/handlers/delete_todo.ts
+++ b/apps/server/src/handlers/delete_todo.ts
@@ -4,21 +4,21 @@ import type {
 	DeleteTodoResponse,
 	TodoParams,
 } from "@natoboram/gigachads.ts-client"
-import type { RequestHandler } from "express"
-import type { LocalsObj } from "../express/locals_obj.ts"
+import type { Locals, RequestHandler } from "express"
 import { todos } from "../models/todo.ts"
 
-// eslint-disable-next-line func-style
-export const deleteTodo: RequestHandler<
+type DeleteTodo = RequestHandler<
 	TodoParams,
 	DeleteTodoResponse,
 	DeleteTodoBody,
 	DeleteTodoQuery,
-	LocalsObj
-> = (req, res) => {
+	Locals
+>
+
+export const deleteTodo: DeleteTodo = ((req, res) => {
 	const index = todos.findIndex(todo => todo.id === req.params.id)
 	if (index === -1) return void res.sendStatus(404)
 
 	todos.splice(index, 1)
 	return void res.json()
-}
+}) satisfies DeleteTodo

--- a/apps/server/src/handlers/get_todo.ts
+++ b/apps/server/src/handlers/get_todo.ts
@@ -4,20 +4,20 @@ import type {
 	GetTodoResponse,
 	TodoParams,
 } from "@natoboram/gigachads.ts-client"
-import type { RequestHandler } from "express"
-import type { LocalsObj } from "../express/locals_obj.ts"
+import type { Locals, RequestHandler } from "express"
 import { todos } from "../models/todo.ts"
 
-// eslint-disable-next-line func-style
-export const getTodo: RequestHandler<
+type GetTodo = RequestHandler<
 	TodoParams,
 	GetTodoResponse,
 	GetTodoBody,
 	GetTodoQuery,
-	LocalsObj
-> = (req, res) => {
+	Locals
+>
+
+export const getTodo: GetTodo = ((req, res) => {
 	const found = todos.find(todo => todo.id === req.params.id)
 	if (!found) return void res.sendStatus(404)
 
 	return void res.json(found)
-}
+}) satisfies GetTodo

--- a/apps/server/src/handlers/get_todos.ts
+++ b/apps/server/src/handlers/get_todos.ts
@@ -4,18 +4,18 @@ import type {
 	GetTodosResponse,
 	TodosParams,
 } from "@natoboram/gigachads.ts-client"
-import type { RequestHandler } from "express"
-import type { LocalsObj } from "../express/locals_obj.ts"
+import type { Locals, RequestHandler } from "express"
 import { todos } from "../models/todo.ts"
 
-// eslint-disable-next-line func-style
-export const getTodos: RequestHandler<
+type GetTodos = RequestHandler<
 	TodosParams,
 	GetTodosResponse,
 	GetTodosBody,
 	GetTodosQuery,
-	LocalsObj
-> = (req, res) => {
+	Locals
+>
+
+export const getTodos: GetTodos = ((req, res) => {
 	const found = todos.filter(todo => {
 		const query = req.query.done === undefined || todo.done === req.query.done
 		const search =
@@ -36,4 +36,4 @@ export const getTodos: RequestHandler<
 	if (content.length === 0) res.status(204)
 	else res.status(200)
 	return void res.json({ content, limit, page })
-}
+}) satisfies GetTodos

--- a/apps/server/src/handlers/patch_todo.ts
+++ b/apps/server/src/handlers/patch_todo.ts
@@ -4,20 +4,20 @@ import type {
 	PatchTodoResponse,
 	TodoParams,
 } from "@natoboram/gigachads.ts-client"
-import type { RequestHandler } from "express"
-import type { LocalsObj } from "../express/locals_obj.ts"
+import type { Locals, RequestHandler } from "express"
 import type { Mutable } from "../interfaces/mutable.ts"
 import type { Todo } from "../models/todo.ts"
 import { todos } from "../models/todo.ts"
 
-// eslint-disable-next-line func-style
-export const patchTodo: RequestHandler<
+type PatchTodo = RequestHandler<
 	TodoParams,
 	PatchTodoResponse,
 	PatchTodoBody,
 	PatchTodoQuery,
-	LocalsObj
-> = (req, res) => {
+	Locals
+>
+
+export const patchTodo: PatchTodo = ((req, res) => {
 	const index = todos.findIndex(todo => todo.id === req.params.id)
 	if (index === -1) return void res.sendStatus(404)
 
@@ -40,4 +40,4 @@ export const patchTodo: RequestHandler<
 
 	todos[index] = found
 	return void res.json(found)
-}
+}) satisfies PatchTodo

--- a/apps/server/src/handlers/post_todo.ts
+++ b/apps/server/src/handlers/post_todo.ts
@@ -5,19 +5,19 @@ import type {
 	TodosParams,
 } from "@natoboram/gigachads.ts-client"
 import { randomUUID } from "crypto"
-import type { RequestHandler } from "express"
-import type { LocalsObj } from "../express/locals_obj.ts"
+import type { Locals, RequestHandler } from "express"
 import { todos } from "../models/todo.ts"
 
-// eslint-disable-next-line func-style
-export const postTodo: RequestHandler<
+type PostTodo = RequestHandler<
 	TodosParams,
 	PostTodoResponse,
 	PostTodoBody,
 	PostTodoQuery,
-	LocalsObj
-> = (req, res) => {
+	Locals
+>
+
+export const postTodo: PostTodo = ((req, res) => {
 	const todo = { done: false, id: randomUUID(), text: req.body.text }
 	todos.push(todo)
 	return void res.json(todo)
-}
+}) satisfies PostTodo

--- a/apps/server/src/handlers/put_todo.ts
+++ b/apps/server/src/handlers/put_todo.ts
@@ -4,20 +4,20 @@ import type {
 	PutTodoResponse,
 	TodoParams,
 } from "@natoboram/gigachads.ts-client"
-import type { RequestHandler } from "express"
-import type { LocalsObj } from "../express/locals_obj.ts"
+import type { Locals, RequestHandler } from "express"
 import type { Mutable } from "../interfaces/mutable.ts"
 import type { Todo } from "../models/todo.ts"
 import { todos } from "../models/todo.ts"
 
-// eslint-disable-next-line func-style
-export const putTodo: RequestHandler<
+type PutTodo = RequestHandler<
 	TodoParams,
 	PutTodoResponse,
 	PutTodoBody,
 	PutTodoQuery,
-	LocalsObj
-> = (req, res) => {
+	Locals
+>
+
+export const putTodo: PutTodo = ((req, res) => {
 	const index = todos.findIndex(todo => todo.id === req.params.id)
 	if (index === -1) return void res.sendStatus(404)
 
@@ -29,4 +29,4 @@ export const putTodo: RequestHandler<
 
 	todos[index] = found
 	return void res.json(found)
-}
+}) satisfies PutTodo

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,6 +1,5 @@
 export * from "./app.ts"
 export * from "./env.ts"
-export type * from "./express/index.ts"
 export * from "./handlers/index.ts"
 export type * from "./interfaces/index.ts"
 export * from "./middlewares/index.ts"

--- a/apps/server/src/middlewares/use_token.ts
+++ b/apps/server/src/middlewares/use_token.ts
@@ -1,20 +1,20 @@
-import type { RequestHandler } from "express"
+import type { Locals, RequestHandler } from "express"
+import type { ParamsDictionary } from "express-serve-static-core"
+import type { ParsedQs } from "qs"
 import { TOKEN } from "../env.ts"
-import type { LocalsObj } from "../express/locals_obj.ts"
-import type { ParamsDictionary } from "../express/params_dictionary.ts"
-import type { ParsedQs } from "../express/parsed_qs.ts"
 
-// eslint-disable-next-line func-style
-export const useToken: RequestHandler<
+type UseToken = RequestHandler<
 	ParamsDictionary,
 	undefined,
 	undefined,
 	ParsedQs,
-	LocalsObj
-> = (req, res, next) => {
+	Locals
+>
+
+export const useToken: UseToken = ((req, res, next) => {
 	if (!req.headers.authorization) return void res.sendStatus(401)
 	if (req.headers.authorization !== `Bearer ${TOKEN}`)
 		return void res.sendStatus(403)
 
 	next()
-}
+}) satisfies UseToken

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,12 @@ importers:
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.3
+      '@types/express-serve-static-core':
+        specifier: ^5.0.7
+        version: 5.0.7
+      '@types/qs':
+        specifier: ^6.14.0
+        version: 6.14.0
       eslint:
         specifier: ^9.32.0
         version: 9.36.0(jiti@2.6.1)
@@ -554,8 +560,8 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/express-serve-static-core@5.0.6':
-    resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
+  '@types/express-serve-static-core@5.0.7':
+    resolution: {integrity: sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==}
 
   '@types/express@5.0.3':
     resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
@@ -2220,9 +2226,9 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/express-serve-static-core@5.0.6':
+  '@types/express-serve-static-core@5.0.7':
     dependencies:
-      '@types/node': 24.0.10
+      '@types/node': 24.6.2
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.5
@@ -2230,7 +2236,7 @@ snapshots:
   '@types/express@5.0.3':
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 5.0.6
+      '@types/express-serve-static-core': 5.0.7
       '@types/serve-static': 1.15.8
 
   '@types/hast@3.0.4':
@@ -2254,7 +2260,6 @@ snapshots:
   '@types/node@24.6.2':
     dependencies:
       undici-types: 7.13.0
-    optional: true
 
   '@types/qs@6.14.0': {}
 
@@ -2263,7 +2268,7 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 24.0.10
+      '@types/node': 24.6.2
 
   '@types/serve-static@1.15.8':
     dependencies:
@@ -3673,8 +3678,7 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  undici-types@7.13.0:
-    optional: true
+  undici-types@7.13.0: {}
 
   undici-types@7.8.0: {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Aligned server handlers and middleware to use standard Express types, reducing custom type usage.
  - Removed re-exports of certain Express-related types, reducing the public API surface. TypeScript consumers should import these types directly from upstream packages.
- Chores
  - Added development type definitions to improve editor and build-time type accuracy.

Note: This may affect TypeScript projects that previously imported server-specific type aliases from this package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->