### PR TITLE
👽️ Fix pnpm in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,6 @@ node_modules
 # Files
 .dockerignore
 .editorconfig
-.gitignore
 .markdownlint-cli2.yaml
 .markdownlint.yaml
 .prettierignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM node:25-slim AS base
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/*
-RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
+FROM ghcr.io/pnpm/pnpm AS base
+RUN pnpm runtime set node --global
 
 FROM base AS build
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm run build
-RUN pnpm deploy --filter=@natoboram/gigachads.ts-server --prod /prod/server
+RUN pnpm deploy --filter=@natoboram/gigachads.ts-server --legacy --prod /prod/server
 
 FROM base AS server
 COPY --from=build /prod/server /prod/server

--- a/apps/server/.dockerignore
+++ b/apps/server/.dockerignore
@@ -6,7 +6,6 @@ node_modules
 
 # Files
 .dockerignore
-.gitignore
 .prettierignore
 .prettierrc.yaml
 *.md

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,15 +1,12 @@
-FROM node:25-slim AS base
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/*
-RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
+FROM ghcr.io/pnpm/pnpm AS base
+RUN pnpm runtime set node --global
 
 FROM base AS build
 COPY --from=repo . /usr/src/app
 WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm run build --filter=@natoboram/gigachads.ts-server
-RUN pnpm deploy --filter=@natoboram/gigachads.ts-server --prod /prod/server
+RUN pnpm deploy --filter=@natoboram/gigachads.ts-server --legacy --prod /prod/server
 
 FROM base AS server
 COPY --from=build /prod/server /prod/server

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -86,7 +86,7 @@
 		"typescript-eslint": "~8.56.1",
 		"vitest": "^4.0.18"
 	},
-	"packageManager": "pnpm@10.30.2+sha512.36cdc707e7b7940a988c9c1ecf88d084f8514b5c3f085f53a2e244c2921d3b2545bc20dd4ebe1fc245feec463bb298aecea7a63ed1f7680b877dc6379d8d0cb4",
+	"packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
 	"type": "module",
 	"types": "dist/index.d.ts",
 	"module": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,6 @@
 		"apps/*",
 		"packages/*"
 	],
-	"packageManager": "pnpm@10.30.2+sha512.36cdc707e7b7940a988c9c1ecf88d084f8514b5c3f085f53a2e244c2921d3b2545bc20dd4ebe1fc245feec463bb298aecea7a63ed1f7680b877dc6379d8d0cb4",
+	"packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
 	"type": "module"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -69,7 +69,7 @@
 		"typescript-eslint": "~8.56.1",
 		"vitest": "^4.0.18"
 	},
-	"packageManager": "pnpm@10.30.2+sha512.36cdc707e7b7940a988c9c1ecf88d084f8514b5c3f085f53a2e244c2921d3b2545bc20dd4ebe1fc245feec463bb298aecea7a63ed1f7680b877dc6379d8d0cb4",
+	"packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
 	"type": "module",
 	"types": "dist/index.d.ts",
 	"module": "dist/index.js"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -53,6 +53,6 @@
 		"typescript": "6.0.3",
 		"typescript-eslint": "~8.56.1"
 	},
-	"packageManager": "pnpm@10.30.2+sha512.36cdc707e7b7940a988c9c1ecf88d084f8514b5c3f085f53a2e244c2921d3b2545bc20dd4ebe1fc245feec463bb298aecea7a63ed1f7680b877dc6379d8d0cb4",
+	"packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
 	"type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
-  injectWorkspacePackages: true
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,5 @@ packages:
   - apps/*
   - packages/*
 
-ignoredBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog

### Changed
- 📌 Pin `packageManager` to `pnpm@11.9.0` in `package.json`, `apps/server/package.json`, `packages/client/package.json`, `packages/config/package.json`
- 👷 Switch Docker `base` stages to `ghcr.io/pnpm/pnpm` in `Dockerfile` and `apps/server/Dockerfile`
- 🔧 Disable `esbuild` builds via `allowBuilds.esbuild: false` in `pnpm-workspace.yaml`
- 🚀 Replace `pnpm deploy` args to use `--legacy` and `--prod /prod/server` in `Dockerfile`
- 🔧 Remove `.gitignore` from ignore list in `.dockerignore` and `apps/server/.dockerignore`

### Fixed
- 🐛 Set `pnpm runtime set node --global` in Docker builds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->